### PR TITLE
feat: reuse expensive resources between loop iterations

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,17 @@
-HF_TOKEN_PATH=/home/mambauser/.huggingface/token
+HF_TOKEN_PATH=/root/.cache/token
 GROBID_SERVER=grobid
+LOG_LEVEL=DEBUG
+
+# If MAX_WORKERS > 1, use process pool
+# If MAX_WORKERS is 0, 1, or negative, then run synchronously in a loop
+REACTIONMINER_MAX_WORKERS=1
+
+REACTIONMINER_SCRATCH_DIR='extraction/results'
+REACTIONMINER_OUTPUT_DIR='extraction/results_filtered'
 
 CHEMSCRAPER_INDEX_NAME='test'  # any unique string, use this when calling /search
 CHEMSCRAPER_PDF_INPUT_DIR='/workspace/10test'
 CHEMSCRAPER_REACTIONMINER_JSON_DIR='/workspace/extraction/results_filtered'
 
-CHEMSCRAPER_BASE_URL='http://chemscraper-services-staging.svc.cluster.local:8000'
+CHEMSCRAPER_BASE_URL='https://chemscraper.backend.staging.mmli1.ncsa.illinois.edu'
 CHEMSCRAPER_OUTPUT_DIR='/workspace/extraction/results_filtered'

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,9 @@ COPY segmentation ./segmentation
 
 # pdf2text is needed by extraction for config.py
 COPY pdf2text/config.py ./extraction/config.py
+COPY chemscraper ./chemscraper
 COPY run_reactionminer.py ./run_reactionminer.py
 COPY run_chemscraper.py ./run_chemscraper.py
-COPY chemscraper ./chemscraper
 
 # Run our docker entrypoint to execute the full workflow
 COPY entrypoint.sh ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY segmentation ./segmentation
 
 # pdf2text is needed by extraction for config.py
 COPY pdf2text/config.py ./extraction/config.py
-COPY example.py ./example.py
+COPY run_reactionminer.py ./run_reactionminer.py
 COPY run_chemscraper.py ./run_chemscraper.py
 COPY chemscraper ./chemscraper
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   # pdf2text + ReactionMiner
   reactionminer:
-    image: moleculemaker/reactionminer
+    image: moleculemaker/reactionminer:chemscraper
     build:
       context: .
     env_file:
@@ -28,15 +28,20 @@ services:
     volumes:
       # Uncomment to map in source code for live dev
       #- .:/workspace
+      - ./chemscraper-output:/workspace/chemscraper-output
+      - ./run_chemscraper.py:/workspace/run_chemscraper.py
+      - ./run_reactionminer.py:/workspace/run_reactionminer.py
+      - ./chemscraper:/workspace/chemscraper
 
       # HuggingFace API token
       - ./.huggingface/token:/root/.cache/token
+      - ./.huggingface/hub:/root/.cache/huggingface/hub
 
       # Input files
       - ./inputs:/workspace/10test/
 
       # Output files
-      - ./results:/workspace/extraction/results_filtered/
+      #- ./results:/workspace/extraction/results_filtered/
     depends_on:
       grobid:
         condition: service_healthy
@@ -44,7 +49,8 @@ services:
 
   # See https://grobid.readthedocs.io/en/latest/Grobid-docker/
   grobid:
-    image: grobid/grobid:0.7.3
+    image: lfoppiano/grobid:0.7.3
+    pull_policy: if_not_present
     networks:
     - reactionminer
     healthcheck:
@@ -54,3 +60,5 @@ services:
       retries: 3
       start_period: 40s
       start_interval: 5s
+    #profiles:
+    #  - donotstart

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ echo '###########################################'
 echo '#######    RUNNING ReactionMiner    #######'
 echo '###########################################'
 cd /workspace
-python ./example.py
+python ./run_reactionminer.py
 
 # Run ChemScraper using input PDF and ReactionMiner JSON output
 echo '###########################################'

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -185,6 +185,8 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         logger.error(traceback.format_exc())
+        sys.exit(1)
+    finally:
+        logger.warning(f'Cleaning up resources...')
         gc.collect()
         torch.cuda.empty_cache()
-        sys.exit(1)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -134,10 +134,10 @@ def read_file_bytes(path) -> BinaryIO:
 
 
 # Write ChemScraper JSON response to file
-def write_json_output(output_file_path):
+def write_json_output(output_file_path, response):
     logger.info(f'Writing response to file: {output_file_path}')
     with open(output_file_path, "w") as f:
-        f.write(str(response))
+        f.write(response.json())
 
 # Walk directory and build up a mapping to submit to ChemScraper
 # exit with error code = 1 if any error encountered
@@ -161,7 +161,7 @@ if __name__ == "__main__":
             # TODO: handle response errors?
             #response.raise_for_status()
             output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-            write_json_output(output_file_path=output_file_path)
+            write_json_output(output_file_path=output_file_path, response=response)
 
     except Exception as ex:
         logger.error(f'ERROR: {ex}')

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import logging
 import os
@@ -8,6 +9,8 @@ import sys
 import traceback
 from typing import BinaryIO
 from io import BytesIO
+
+import torch
 
 from chemscraper.fast_api_client import Client
 from chemscraper.fast_api_client.models import HTTPValidationError
@@ -182,4 +185,6 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         logger.error(traceback.format_exc())
+        gc.collect()
+        torch.cuda.empty_cache()
         sys.exit(1)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+from urllib.error import HTTPError
+
 import requests
 import sys
 import traceback
@@ -135,10 +137,10 @@ def read_file_bytes(path) -> BinaryIO:
 
 
 # Write ChemScraper JSON response to file
-def write_json_output(output_file_path, response):
+def write_json_output(output_file_path, json_response):
     logger.info(f'Writing response to file: {output_file_path}')
     with open(output_file_path, "w") as f:
-        f.write(json.dumps(response))
+        f.write(json_response)
 
 # Walk directory and build up a mapping to submit to ChemScraper
 # exit with error code = 1 if any error encountered
@@ -159,10 +161,14 @@ if __name__ == "__main__":
 
         # Write JSON response to file
         if response is not None:
-            # TODO: handle response errors?
+            # Convert response dictionary to JSON
+            json_response = json.dumps(response)
             #response.raise_for_status()
             output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-            write_json_output(output_file_path=output_file_path, response=response)
+            write_json_output(output_file_path=output_file_path, json_response=json_response)
+        else:
+            # handle response errors?
+            raise HTTPError('ERROR: Empty response encountered')
 
     except Exception as ex:
         logger.error(f'ERROR: {ex}')

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -2,6 +2,7 @@ import logging
 import os
 import requests
 import sys
+import traceback
 from typing import BinaryIO
 from io import BytesIO
 
@@ -13,9 +14,11 @@ from chemscraper.fast_api_client.api.default.index_pdfs_reactions_batch_index_pd
 logging.basicConfig(
     format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.DEBUG
+    level=logging.INFO
 )
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 logger = logging.getLogger('run_chemscraper')
+logger.setLevel(LOG_LEVEL)
 
 # Path to input PDFs for RM+CS
 # Files in this path will be automatically downloaded from MinIO before running the AlphaSynthesis job
@@ -65,7 +68,7 @@ def parse_input_files(pdf_input_dir):
                     logger.warning(f"  No matching JSON file found: {file}")
                 else:
                     # For each matching PDF-JSON pair, add to CSV mapping
-                    logger.info(f"  Matching JSON file found: {json_file_name}")
+                    logger.info(f"     Matching JSON file found: {json_file_name}")
 
                     # Maintain lists of these pairs to submit at the end
                     mapping[pdf_file_name] = json_file_name
@@ -150,14 +153,17 @@ if __name__ == "__main__":
         pdf_files, json_files, mapping = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
         response = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
 
+        # Raise error status if no response body
+        logger.debug("Response: " + str(response))
+
         # Write JSON response to file
         if response is not None:
-            logger.debug("Response: " + str(response))
+            # TODO: handle response errors?
+            #response.raise_for_status()
             output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
             write_json_output(output_file_path=output_file_path)
-        else:
-            # Raise error status if no response body
-            response.raise_for_status()
+
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
+        logger.error(traceback.format_exc())
         sys.exit(1)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import requests
@@ -137,7 +138,7 @@ def read_file_bytes(path) -> BinaryIO:
 def write_json_output(output_file_path, response):
     logger.info(f'Writing response to file: {output_file_path}')
     with open(output_file_path, "w") as f:
-        f.write(response.json())
+        f.write(json.dumps(response))
 
 # Walk directory and build up a mapping to submit to ChemScraper
 # exit with error code = 1 if any error encountered

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -10,6 +10,7 @@ from typing import BinaryIO
 from io import BytesIO
 
 from chemscraper.fast_api_client import Client
+from chemscraper.fast_api_client.models import HTTPValidationError
 from chemscraper.fast_api_client.types import File
 from chemscraper.fast_api_client.api.default import index_pdfs_reactions_batch_index_pdfs_reactions_batch_post as index_pdfs_reactions_batch
 from chemscraper.fast_api_client.api.default.index_pdfs_reactions_batch_index_pdfs_reactions_batch_post import BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost as IndexPdfsReactionsBatchPostBody
@@ -42,6 +43,7 @@ CHEMSCRAPER_INDEX_NAME = os.environ.get('CHEMSCRAPER_INDEX_NAME', os.environ.get
 # Base URL to ChemScraper API
 # We will override this default in production
 CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-services-staging.staging.svc.cluster.local:8000')
+
 
 # Read PDFs + locate matching JSONs on disk
 # Create a mapping of PDF file -> JSON file
@@ -98,8 +100,9 @@ def save_mapping_csv(file_path, mapping):
             f.write(f'{index},{pdf_file},{json_file}\n')
             index += 1
 
+
 # Submit mapping + related files to Chemscraper API
-def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
+def submit_to_chemscraper(index_name: str, pdf_files, json_files, mapping):
     # Save mapping.csv to disk, upload to MinIO later
     mapping_csv_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')
     save_mapping_csv(file_path=mapping_csv_file_path, mapping=mapping)
@@ -107,40 +110,46 @@ def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
     # Create a new ChemScraper API client and submit the
     # PDF + JSON files and the mapping that links them
     with Client(base_url=CHEMSCRAPER_BASE_URL) as client:
-        return index_pdfs_reactions_batch.sync(client=client, index_name=index_name, body=IndexPdfsReactionsBatchPostBody(
-            # Our list of ReactionMiner PDF inputs
-            pdf_files=[File(
-                file_name=file.split('/')[-1],
-                payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, file)),
-                mime_type='application/pdf'
-            ) for file in pdf_files],
+        return index_pdfs_reactions_batch.sync(
+            client=client,
+            index_name=index_name,
+            body=IndexPdfsReactionsBatchPostBody(
+                # Our list of ReactionMiner PDF inputs
+                pdf_files=[File(
+                    file_name=file.split('/')[-1],
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, file)),
+                    mime_type='application/pdf'
+                ) for file in pdf_files],
 
-            # Our list of ReactionMiner JSON outputs
-            json_reaction_files=[File(
-                file_name=file.split('/')[-1],
-                payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, file)),
-                mime_type='application/json'
-            ) for file in json_files],
+                # Our list of ReactionMiner JSON outputs
+                json_reaction_files=[File(
+                    file_name=file.split('/')[-1],
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, file)),
+                    mime_type='application/json'
+                ) for file in json_files],
 
-            # The CSV created earlier that maps PDF file -> JSON file
-            mapping_file=File(
-                file_name='mapping.csv',
-                payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')),
-                mime_type='text/csv'
-            ),
-        ))
+                # The CSV created earlier that maps PDF file -> JSON file
+                mapping_file=File(
+                    file_name='mapping.csv',
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')),
+                    mime_type='text/csv'
+                ),
+            )
+        )
+
 
 # TODO: Read large files in chunks?
-def read_file_bytes(path) -> BinaryIO:
+def read_file_bytes(path: str) -> BinaryIO:
     with open(path, mode='rb') as f:
         return BytesIO(f.read())
 
 
 # Write ChemScraper JSON response to file
-def write_json_output(output_file_path, json_response):
-    logger.info(f'Writing response to file: {output_file_path}')
-    with open(output_file_path, "w") as f:
-        f.write(json_response)
+def write_json_output(output_path: str, response: HTTPValidationError):
+    logger.info(f'Writing response to file: {output_path}')
+    with open(output_path, "w") as f:
+        json.dump(response, f, indent=4, ensure_ascii=False)
+
 
 # Walk directory and build up a mapping to submit to ChemScraper
 # exit with error code = 1 if any error encountered
@@ -154,20 +163,18 @@ if __name__ == "__main__":
 
     try:
         pdf_files, json_files, mapping = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
-        response = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
+        resp = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
 
         # Raise error status if no response body
-        logger.debug("Response: " + str(response))
+        logger.debug("Response: " + str(resp))
 
         # Write JSON response to file
-        if response is not None:
+        if resp is not None:
             # Convert response dictionary to JSON
-            json_response = json.dumps(response)
-            #response.raise_for_status()
             output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-            write_json_output(output_file_path=output_file_path, json_response=json_response)
+            write_json_output(output_path=output_file_path, response=resp)
         else:
-            # handle response errors?
+            # Handle response errors
             raise HTTPError('ERROR: Empty response encountered')
 
     except Exception as ex:

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -188,5 +188,7 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         logger.warning(f'Cleaning up resources...')
-        gc.collect()
+        collected_count = gc.collect()
+        logger.warning(f'Cleaned up resources: {collected_count}')
         torch.cuda.empty_cache()
+        logger.warning(f'Cache has been emptied. Shutting down...')

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -148,7 +148,9 @@ def read_file_bytes(path: str) -> BinaryIO:
 def write_json_output(output_path: str, response: HTTPValidationError):
     logger.info(f'Writing response to file: {output_path}')
     with open(output_path, "w") as f:
-        json.dump(response, f, indent=4, ensure_ascii=False)
+        json_contents = json.dumps(response, indent=4, ensure_ascii=False)
+        logger.debug("Writing JSON contents: " + json_contents)
+        f.write(json_contents)
 
 
 # Walk directory and build up a mapping to submit to ChemScraper
@@ -166,7 +168,7 @@ if __name__ == "__main__":
         resp = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
 
         # Raise error status if no response body
-        logger.debug("Response: " + json.dumps(resp))
+        logger.debug("Response: " + str(resp))
 
         # Write JSON response to file
         if resp is not None:

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
         resp = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
 
         # Raise error status if no response body
-        logger.debug("Response: " + str(resp))
+        logger.debug("Response: " + json.dumps(resp))
 
         # Write JSON response to file
         if resp is not None:

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -118,6 +118,8 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         logger.warning(f'Cleaning up resources...')
-        gc.collect()
+        collected_count = gc.collect()
+        logger.warning(f'Cleaned up resources: {collected_count}')
         torch.cuda.empty_cache()
+        logger.warning(f'Cache has been emptied. Shutting down...')
 

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -1,6 +1,7 @@
 import os
 import json
-from os.path import join
+import logging
+import sys
 
 from segmentation.segmentor import TopicSegmentor
 from extraction.extractor import ReactionExtractor
@@ -37,7 +38,7 @@ def process_file(filename):
         write_path = 'extraction/results'
         os.makedirs(write_path, exist_ok=True)
         reaction_path = os.path.basename(file_path)
-        full_path = join(write_path, reaction_path)
+        full_path = os.path.join(write_path, reaction_path)
         logger.info(f"Writing outputs: {write_path}")
         with open(full_path, 'w', encoding='utf-8') as f:
             logger.debug(f"Writing file: {full_path}")

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -60,7 +60,7 @@ def process_file(root, filename):
         os.makedirs(write_path, exist_ok=True)
         reaction_path = os.path.basename(file_path)
         full_path = os.path.join(write_path, reaction_path)
-        tasklogger.info(f"Writing outputs: {write_path}")
+        tasklogger.info(f"Writing outputs: {full_path}")
         with open(full_path, 'w', encoding='utf-8') as f:
             tasklogger.debug(f"Writing file: {full_path}")
             json.dump(reactions, f, indent=4, ensure_ascii=False)

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -117,7 +117,9 @@ if __name__ == "__main__":
         logger.error(traceback.format_exc())
         sys.exit(1)
     finally:
-        logger.warning(f'Cleaning up resources...')
+        logger.warning(f'Cleaning up model & resources...')
+        del segmentor
+        del extractor
         collected_count = gc.collect()
         logger.warning(f'Cleaned up resources: {collected_count}')
         torch.cuda.empty_cache()

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -1,0 +1,70 @@
+import os
+import json
+from os.path import join
+
+from segmentation.segmentor import TopicSegmentor
+from extraction.extractor import ReactionExtractor
+from extraction.extract_postprocess import extract_postprocess
+
+logging.basicConfig(
+    format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.DEBUG
+)
+logger = logging.getLogger('run_reactionminer')
+
+# Run pdf2text and then ReactionMiner
+def process_file(filename):
+    logger.debug(f"JSON file found! Processing {filename}...")
+    file_path = os.path.join(root, filename)
+    logger.info("########## Stage I: Reading File ##########")
+    with open(file_path, 'r', encoding='utf-8') as json_file:
+        result = json.load(json_file)
+        #full_text = result['fullText']  # Text without paragraph information
+        paragraphs = result['content']  # Text with paragraph boundaries
+
+        # Stage II: text segmentation
+        logger.info("########## Stage II: Text Segmentation ##########")
+        segmentor = TopicSegmentor()
+        seg_texts = segmentor.segment(paragraphs)
+
+        # Stage III: reaction extraction
+        logger.info("########## Stage III: Reaction Extraction ##########")
+        extractor = ReactionExtractor('8b')
+        logger.debug("Now extracting...")
+        reactions = extractor.extract(seg_texts)
+        logger.debug("Done extracting!")
+        write_path = 'extraction/results'
+        os.makedirs(write_path, exist_ok=True)
+        reaction_path = os.path.basename(file_path)
+        full_path = join(write_path, reaction_path)
+        logger.info(f"Writing outputs: {write_path}")
+        with open(full_path, 'w', encoding='utf-8') as f:
+            logger.debug(f"Writing file: {full_path}")
+            json.dump(reactions, f, indent=4, ensure_ascii=False)
+        logger.debug(f"Done writing!")
+        extract_postprocess(write_path, 'extraction/results_filtered')
+        logger.info(f"The results are stored in {full_path}")
+
+        return True
+
+if __name__ == "__main":
+    # The results will be automatically saved to pdf2text/results
+    directory = 'results'
+    logger.info(f"Searching for {directory}")
+    FILES = []
+
+    try:
+        for root, _, files in os.walk(directory):  # Walk through directory tree
+            for filename in files:
+                logger.debug(f"Checking {filename}")
+                if filename.endswith(".json"):
+                    FILES.append(filename)
+                else:
+                    logger.warning(f"Skipping {filename}: JSON format required")
+
+            with concurrent.futures.ProcessPoolExecutor() as executor:
+                for filename, in zip(FILES, executor.map(process_file, FILES)):
+    except Exception as ex:
+        logger.error(f'ERROR: {ex}')
+        sys.exit(1)

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -64,7 +64,8 @@ if __name__ == "__main":
                     logger.warning(f"Skipping {filename}: JSON format required")
 
             with concurrent.futures.ProcessPoolExecutor() as executor:
-                for filename, in zip(FILES, executor.map(process_file, FILES)):
+                for filename in zip(FILES, executor.map(process_file, FILES)):
+                    logger.debug(f'Finished processing: {filename}')
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         sys.exit(1)

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -2,7 +2,6 @@ import os
 import json
 import logging
 import sys
-import time
 import traceback
 from concurrent.futures import ProcessPoolExecutor, wait
 
@@ -19,6 +18,7 @@ LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 logger = logging.getLogger('run_reactionminer')
 logger.setLevel(LOG_LEVEL)
 
+# TODO: EXPERIMENTAL
 # If MAX_WORKERS > 1, use process pool
 # If MAX_WORKERS is 0, 1, or negative, then run synchronously in a loop
 REACTIONMINER_MAX_WORKERS = int(os.getenv('REACTIONMINER_MAX_WORKERS', '1'))
@@ -32,6 +32,7 @@ REACTIONMINER_OUTPUT_DIR = os.getenv('REACTIONMINER_OUTPUT_DIR', 'extraction/res
 segmentor = TopicSegmentor()
 extractor = ReactionExtractor('8b')
 
+
 # Run pdf2text and then ReactionMiner
 def process_file(root, filename):
     tasklogger = logging.getLogger(f'reactionminer:process_file[{filename}]')
@@ -42,7 +43,7 @@ def process_file(root, filename):
         tasklogger.debug(f"JSON file found! Processing {file_path}...")
         result = json.load(json_file)
 
-        #full_text = result['fullText']  # Text without paragraph information
+        # full_text = result['fullText']  # Text without paragraph information
         paragraphs = result['content']  # Text with paragraph boundaries
 
         # Stage II: text segmentation
@@ -68,6 +69,7 @@ def process_file(root, filename):
 
     return True
 
+
 if __name__ == "__main__":
     # The results will be automatically saved to pdf2text/results
     directory = 'results'
@@ -85,10 +87,11 @@ if __name__ == "__main__":
                         FILES.append(filename)
                     else:
                         # Run synchronously:
-                        process_file(root, filename)
+                        process_file(root=root, filename=filename)
                 else:
                     logger.warning(f"Skipping {filename}: JSON format required")
 
+            # TODO: EXPERIMENTAL
             # If max workers > 1, run asynchronously using a process pool
             if REACTIONMINER_MAX_WORKERS > 1:
                 with ProcessPoolExecutor(max_workers=REACTIONMINER_MAX_WORKERS) as executor:
@@ -110,3 +113,4 @@ if __name__ == "__main__":
         logger.error(f'ERROR: {ex}')
         logger.error(traceback.format_exc())
         sys.exit(1)
+

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -1,9 +1,12 @@
+import gc
 import os
 import json
 import logging
 import sys
 import traceback
 from concurrent.futures import ProcessPoolExecutor, wait
+
+import torch
 
 from segmentation.segmentor import TopicSegmentor
 from extraction.extractor import ReactionExtractor
@@ -112,5 +115,7 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         logger.error(traceback.format_exc())
+        gc.collect()
+        torch.cuda.empty_cache()
         sys.exit(1)
 

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -115,7 +115,9 @@ if __name__ == "__main__":
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         logger.error(traceback.format_exc())
+        sys.exit(1)
+    finally:
+        logger.warning(f'Cleaning up resources...')
         gc.collect()
         torch.cuda.empty_cache()
-        sys.exit(1)
 

--- a/run_reactionminer.py
+++ b/run_reactionminer.py
@@ -2,6 +2,9 @@ import os
 import json
 import logging
 import sys
+import time
+import traceback
+from concurrent.futures import ProcessPoolExecutor, wait
 
 from segmentation.segmentor import TopicSegmentor
 from extraction.extractor import ReactionExtractor
@@ -10,49 +13,66 @@ from extraction.extract_postprocess import extract_postprocess
 logging.basicConfig(
     format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.DEBUG
+    level=logging.INFO
 )
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 logger = logging.getLogger('run_reactionminer')
+logger.setLevel(LOG_LEVEL)
+
+# If MAX_WORKERS > 1, use process pool
+# If MAX_WORKERS is 0, 1, or negative, then run synchronously in a loop
+REACTIONMINER_MAX_WORKERS = int(os.getenv('REACTIONMINER_MAX_WORKERS', '1'))
+
+# You can override these if needed
+REACTIONMINER_SCRATCH_DIR = os.getenv('REACTIONMINER_SCRATCH_DIR', 'extraction/results')
+REACTIONMINER_OUTPUT_DIR = os.getenv('REACTIONMINER_OUTPUT_DIR', 'extraction/results_filtered')
+
+# Phase 2/3 use these shared resources
+# These are expensive, so we reuse them across all loop iterations
+segmentor = TopicSegmentor()
+extractor = ReactionExtractor('8b')
 
 # Run pdf2text and then ReactionMiner
-def process_file(filename):
-    logger.debug(f"JSON file found! Processing {filename}...")
+def process_file(root, filename):
+    tasklogger = logging.getLogger(f'reactionminer:process_file[{filename}]')
+
+    tasklogger.info("########## Stage I: Reading File ##########")
     file_path = os.path.join(root, filename)
-    logger.info("########## Stage I: Reading File ##########")
     with open(file_path, 'r', encoding='utf-8') as json_file:
+        tasklogger.debug(f"JSON file found! Processing {file_path}...")
         result = json.load(json_file)
+
         #full_text = result['fullText']  # Text without paragraph information
         paragraphs = result['content']  # Text with paragraph boundaries
 
         # Stage II: text segmentation
-        logger.info("########## Stage II: Text Segmentation ##########")
-        segmentor = TopicSegmentor()
+        tasklogger.info("########## Stage II: Text Segmentation ##########")
         seg_texts = segmentor.segment(paragraphs)
 
         # Stage III: reaction extraction
-        logger.info("########## Stage III: Reaction Extraction ##########")
-        extractor = ReactionExtractor('8b')
-        logger.debug("Now extracting...")
+        tasklogger.info("########## Stage III: Reaction Extraction ##########")
+        tasklogger.debug("Now extracting...")
         reactions = extractor.extract(seg_texts)
-        logger.debug("Done extracting!")
-        write_path = 'extraction/results'
+        tasklogger.debug("Done extracting!")
+
+        # Write JSON output file
+        write_path = REACTIONMINER_SCRATCH_DIR
         os.makedirs(write_path, exist_ok=True)
         reaction_path = os.path.basename(file_path)
         full_path = os.path.join(write_path, reaction_path)
-        logger.info(f"Writing outputs: {write_path}")
+        tasklogger.info(f"Writing outputs: {write_path}")
         with open(full_path, 'w', encoding='utf-8') as f:
-            logger.debug(f"Writing file: {full_path}")
+            tasklogger.debug(f"Writing file: {full_path}")
             json.dump(reactions, f, indent=4, ensure_ascii=False)
-        logger.debug(f"Done writing!")
-        extract_postprocess(write_path, 'extraction/results_filtered')
-        logger.info(f"The results are stored in {full_path}")
+        tasklogger.debug(f"Done writing!")
 
-        return True
+    return True
 
-if __name__ == "__main":
+if __name__ == "__main__":
     # The results will be automatically saved to pdf2text/results
     directory = 'results'
-    logger.info(f"Searching for {directory}")
+    logger.info(f"Searching {directory}")
+    logger.debug(f"   Max Workers = {REACTIONMINER_MAX_WORKERS}")
     FILES = []
 
     try:
@@ -60,13 +80,33 @@ if __name__ == "__main":
             for filename in files:
                 logger.debug(f"Checking {filename}")
                 if filename.endswith(".json"):
-                    FILES.append(filename)
+                    if REACTIONMINER_MAX_WORKERS > 1:
+                        # Run with process pool
+                        FILES.append(filename)
+                    else:
+                        # Run synchronously:
+                        process_file(root, filename)
                 else:
                     logger.warning(f"Skipping {filename}: JSON format required")
 
-            with concurrent.futures.ProcessPoolExecutor() as executor:
-                for filename in zip(FILES, executor.map(process_file, FILES)):
-                    logger.debug(f'Finished processing: {filename}')
+            # If max workers > 1, run asynchronously using a process pool
+            if REACTIONMINER_MAX_WORKERS > 1:
+                with ProcessPoolExecutor(max_workers=REACTIONMINER_MAX_WORKERS) as executor:
+                    logger.info(f'Starting tasks...')
+                    futures = [executor.submit(process_file, root, file) for file in FILES]
+                    logger.debug(f'Finished submission!')
+
+                    logger.debug('Waiting for tasks to complete...')
+                    wait(futures)
+                    logger.info('All tasks are done!')
+
+            # Run postprocessing
+            logger.info('Running postprocessing...')
+            extract_postprocess(REACTIONMINER_SCRATCH_DIR, REACTIONMINER_OUTPUT_DIR)
+            logger.info('File processing complete!')
+            logger.info(f"The results are stored in {REACTIONMINER_SCRATCH_DIR}")
+
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
+        logger.error(traceback.format_exc())
         sys.exit(1)


### PR DESCRIPTION
## Problem
One PDF runs just fine, but multiple PDF batches fail with a CUDA OutOfMemory error

## Approach
* fix: reuse ReactionExtractor across multiple loop iterations - this constructor loads a 20GB model file into CUDA memory

## How to Test
1. Upload multiple PDFs to the same jobID in the `reactionminer` bucket
2. Submit ReactionMiner job
3. Wait for job to complete, watch the logs
    * You should see the job executes ReactionMiner one-by-one on each input PDF, and eventually completes successfully