### PR TITLE
feat: run ChemScraper in batches

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,10 @@ LOG_LEVEL=DEBUG
 # If MAX_WORKERS is 0, 1, or negative, then run synchronously in a loop
 REACTIONMINER_MAX_WORKERS=1
 
+# Maximum number of documents per batch to send to ChemScraper
+# If batch size <= 0, then we send everything as a single batch
+CHEMSCRAPER_BATCH_SIZE=10
+
 REACTIONMINER_SCRATCH_DIR='extraction/results'
 REACTIONMINER_OUTPUT_DIR='extraction/results_filtered'
 

--- a/.env
+++ b/.env
@@ -2,18 +2,23 @@ HF_TOKEN_PATH=/root/.cache/token
 GROBID_SERVER=grobid
 LOG_LEVEL=DEBUG
 
+# Set to "true" to disable one or more particular steps
+SKIP_PDF2TEXT=''
+SKIP_REACTIONMINER=''
+SKIP_CHEMSCRAPER=''
+
 # If MAX_WORKERS > 1, use process pool
 # If MAX_WORKERS is 0, 1, or negative, then run synchronously in a loop
 REACTIONMINER_MAX_WORKERS=1
 
 # Maximum number of documents per batch to send to ChemScraper
 # If batch size <= 0, then we send everything as a single batch
-CHEMSCRAPER_BATCH_SIZE=10
+CHEMSCRAPER_BATCH_SIZE=2
 
 REACTIONMINER_SCRATCH_DIR='extraction/results'
 REACTIONMINER_OUTPUT_DIR='extraction/results_filtered'
 
-CHEMSCRAPER_INDEX_NAME='test'  # any unique string, use this when calling /search
+CHEMSCRAPER_INDEX_NAME='lambert8apitest'  # any unique string, use this when calling /search
 CHEMSCRAPER_PDF_INPUT_DIR='/workspace/10test'
 CHEMSCRAPER_REACTIONMINER_JSON_DIR='/workspace/extraction/results_filtered'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime
 # FIXME: Temporary workaround for NFS file permissions issues
 USER root
 
+RUN apt-get -qq update && \
+    apt-get -qq install build-essential && \
+    apt-get -qq autoremove && \
+    apt-get -qq autoclean && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ###################
 #     pdf2text    #
 ###################

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,5 @@ COPY pdf2text/config.py ./extraction/config.py
 COPY chemscraper ./chemscraper
 COPY run_reactionminer.py ./run_reactionminer.py
 COPY run_chemscraper.py ./run_chemscraper.py
-
-# Run our docker entrypoint to execute the full workflow
 COPY entrypoint.sh ./entrypoint.sh
 CMD [ "./entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ COPY pdf2text/config.py ./extraction/config.py
 COPY chemscraper ./chemscraper
 COPY run_reactionminer.py ./run_reactionminer.py
 COPY run_chemscraper.py ./run_chemscraper.py
+COPY models ./models
+COPY services ./services
 
 # Run our docker entrypoint to execute the full workflow
 COPY entrypoint.sh ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,6 @@ COPY pdf2text/config.py ./extraction/config.py
 COPY chemscraper ./chemscraper
 COPY run_reactionminer.py ./run_reactionminer.py
 COPY run_chemscraper.py ./run_chemscraper.py
-COPY models ./models
-COPY services ./services
 
 # Run our docker entrypoint to execute the full workflow
 COPY entrypoint.sh ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,12 @@ echo '######################################'
 echo '#######    RUNNING pdf2text    #######'
 echo '######################################'
 cd /workspace/pdf2text
-conda run --no-capture-output -n doc2json bash ./pdf2txt.sh
+if [[ -z "${SKIP_PDF2TEXT}" ]]; then
+  conda run --no-capture-output -n doc2json bash ./pdf2txt.sh
+else
+  echo 'SKIP_PDF2TEXT is set, skipping pdf2text stage'
+fi
+
 
 # TODO: move files?
 
@@ -20,10 +25,18 @@ echo '###########################################'
 echo '#######    RUNNING ReactionMiner    #######'
 echo '###########################################'
 cd /workspace
-python ./run_reactionminer.py
+if [[ -z "${SKIP_REACTIONMINER}" ]]; then
+  python ./run_reactionminer.py
+else
+  echo 'SKIP_REACTIONMINER is set, skipping ReactionMiner stage'
+fi
 
 # Run ChemScraper using input PDF and ReactionMiner JSON output
 echo '###########################################'
 echo '########    RUNNING ChemScraper    ########'
 echo '###########################################'
-python ./run_chemscraper.py
+if [[ -z "${SKIP_CHEMSCRAPER}" ]]; then
+  python ./run_chemscraper.py
+else
+  echo 'SKIP_CHEMSCRAPER is set, skipping ChemScraper stage'
+fi

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -53,6 +53,9 @@ CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscrape
 
 full_mapping = {}
 
+# Track number of failures - this will be our error code when the process exits
+failures = 0
+
 
 # Read PDFs + locate matching JSONs on disk
 # Create a mapping of PDF file -> JSON file
@@ -201,30 +204,36 @@ if __name__ == "__main__":
             pdf_batch_files = batched_pdfs[index]
             json_batch_files = batched_json[index]
 
-            logger.info(f'Submitting ChemScraper batch ({index+1}/{num_batches})')
+            try:
+                logger.info(f'Submitting ChemScraper batch ({index+1}/{num_batches})')
 
-            # Extract input for each batch and submit to chemscraper API
-            resp = submit_to_chemscraper(
-                index_name=CHEMSCRAPER_INDEX_NAME,
-                pdf_files=pdf_batch_files,
-                json_files=json_batch_files
-            )
+                # Extract input for each batch and submit to chemscraper API
+                resp = submit_to_chemscraper(
+                    index_name=CHEMSCRAPER_INDEX_NAME,
+                    pdf_files=pdf_batch_files,
+                    json_files=json_batch_files
+                )
 
-            # Raise error status if no response body
-            logger.debug("Response: " + str(resp))
+                # Raise error status if no response body
+                logger.debug("Response: " + str(resp))
 
-            # Write JSON response to file
-            if resp is not None:
-                # Convert response dictionary to JSON
-                output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output-batch-{index+1}.json')
-                logger.info(f'Writing ChemScraper (batch {index+1}/{num_batches}) output to file: {output_file_path}')
-                write_json_output(output_path=output_file_path, data={
-                    f'batch-{index+1}': resp
-                })
-            else:
-                # TODO: Handle response errors?
-                # raise ValueError('Empty response encountered')
-                logger.warning(f'Empty response encountered from ChemScraper API: {resp} - skipped writing output JSON')
+                # Write JSON response to file
+                if resp is not None:
+                    # Convert response dictionary to JSON
+                    output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output-batch-{index+1}.json')
+                    logger.info(f'Writing ChemScraper (batch {index+1}/{num_batches}) output to file: {output_file_path}')
+                    write_json_output(output_path=output_file_path, data={
+                        f'batch-{index+1}': resp
+                    })
+                else:
+                    # TODO: Handle response errors?
+                    # raise ValueError('Empty response encountered')
+                    logger.warning(f'Empty response encountered from ChemScraper API: {resp} - skipped writing output JSON')
+            except Exception as ex:
+                logger.error(f'ERROR: {ex}')
+                logger.error(traceback.format_exc())
+                failures += 1
+                pass
 
         # Zip all JSON outputs into a single JSON file for the frontend
         merged_output = {}
@@ -260,13 +269,11 @@ if __name__ == "__main__":
         else:
             logger.error('ERROR: merged_output was empty - check that any batch produced a valid output file')
 
-    except Exception as ex:
-        logger.error(f'ERROR: {ex}')
-        logger.error(traceback.format_exc())
-        sys.exit(1)
     finally:
         logger.warning(f'Cleaning up resources...')
         collected_count = gc.collect()
         logger.warning(f'Cleaned up resources: {collected_count}')
         torch.cuda.empty_cache()
         logger.warning(f'Cache has been emptied. Shutting down...')
+        # exit_code = 0 if failures == 0 else 1
+        sys.exit(failures)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -7,7 +7,7 @@ from urllib.error import HTTPError
 import requests
 import sys
 import traceback
-from typing import BinaryIO, Tuple
+from typing import BinaryIO, Tuple, Any
 from io import BytesIO
 
 import torch
@@ -56,12 +56,10 @@ full_mapping = {}
 
 # Read PDFs + locate matching JSONs on disk
 # Create a mapping of PDF file -> JSON file
-def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[str, str]]]:
-    # Loop to build up CSV mapping and file lists
-    mapping = {}
+def parse_input_files(pdf_input_dir) -> Tuple[list[str], list[str]]:  # , dict[str, str]]:
+    # Loop to collect lists of PDF/JSON file names
     pdf_files = []
     json_files = []
-    batches = []
 
     # Walk input PDF directory looking for PDF files
     for root, _, files in os.walk(pdf_input_dir):
@@ -74,7 +72,6 @@ def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[st
                 # If a PDF is found, check for a matching JSON file
                 pdf_file_name = file
                 logger.info(f"  PDF File: {pdf_file_name}")
-                pdf_file_path = os.path.join(root, file)
                 json_file_name = pdf_file_name.replace('.pdf', '.json')
                 json_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, json_file_name)
 
@@ -85,53 +82,57 @@ def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[st
                     # For each matching PDF-JSON pair, add to CSV mapping
                     logger.info(f"     Matching JSON file found: {json_file_name}")
 
-                    # If this batch is too large, add it to our running list of batches
-                    if 0 < CHEMSCRAPER_BATCH_SIZE < len(pdf_files):
-                        batches.append((pdf_files.copy(), json_files.copy(), mapping.copy()))
-                        pdf_files.clear()
-                        json_files.clear()
-                        mapping.clear()
-
                     # Maintain lists of these pairs to submit at the end
-                    full_mapping[pdf_file_name] = mapping[pdf_file_name] = json_file_name
-                    pdf_files.append(pdf_file_path)
-                    json_files.append(json_file_path)
-
-                    # Make sure to add in the last batch every time
-                    batches.append((pdf_files, json_files, mapping))
+                    pdf_files.append(pdf_file_name)
+                    json_files.append(json_file_name)
 
         logger.debug('PDF Files: ' + str(pdf_files))
         logger.debug('JSON Files: ' + str(json_files))
-        logger.debug('Mapping: ' + str(mapping))
 
         # Return lists of files and CSV mapping
-        return batches
+        return pdf_files, json_files
 
 
-# Write mapping.csv to file, and submit this file with our request
-def save_mapping_csv(file_path: str, mapping: dict[str, str]):
+def split_into_batches(data: list[Any], batch_size=CHEMSCRAPER_BATCH_SIZE) -> list[Any]:
+    return [data[i:i + batch_size] for i in range(0, len(data), batch_size)]
+
+
+# Write mapping as CSV or JSON to file
+def save_mapping_file(file_path: str, mapping: dict[str, str], format: str = 'csv'):
     index = 0
     with open(file_path, 'w') as f:
-        # Write CSV headers - this is important
-        f.write(f'id,pdf_name,json_name\n')
-        for pdf_file in mapping:
+        if format == 'json':
+            # Write as JSON to file
+            json.dump(mapping, f, indent=4)
+        elif format == 'csv':
+            # Write CSV headers - this is important
+            f.write(f'id,pdf_name,json_name\n')
+
             # Read mapping to write CSV line by line
-            json_file = mapping[pdf_file]
-            f.write(f'{index},{pdf_file},{json_file}\n')
-            index += 1
-
-
-# Write mapping.json to file, and save this file to disk
-def save_mapping_json(file_path, mapping):
-    with open(file_path, 'w') as f:
-        json.dump(mapping, f, indent=4)
+            for pdf_file in mapping:
+                json_file = mapping[pdf_file]
+                f.write(f'{index},{pdf_file},{json_file}\n')
+                index += 1
 
 
 # Submit mapping + related files to Chemscraper API
-def submit_to_chemscraper(index_name: str, pdf_files: list[str], json_files: list[str], mapping: dict[str, str]):
+def submit_to_chemscraper(index_name: str, pdf_files: list[str], json_files: list[str]):
+    logger.debug(f'Submitting the following inputs to ChemScraper')
+    logger.debug(f'PDF Files: {str(pdf_files)}')
+    logger.debug(f'JSON Files: {str(json_files)}')
+
+    # Fail if there is a mismatch at this point between PDF and JSON input sizes
+    if len(pdf_files) != len(json_files):
+        raise ValueError("PDF -> JSON size mismatch")
+
+    # Build a mapping from the files we are given
+    mapping = dict(zip(pdf_files, json_files))
+
     # Save mapping.csv to disk, upload to MinIO later
     mapping_csv_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')
-    save_mapping_csv(file_path=mapping_csv_file_path, mapping=mapping)
+    save_mapping_file(file_path=mapping_csv_file_path, mapping=mapping)
+
+    logger.debug(f'Mapping: {str(mapping)}')
 
     # Create a new ChemScraper API client and submit the
     # PDF + JSON files and the mapping that links them
@@ -142,17 +143,17 @@ def submit_to_chemscraper(index_name: str, pdf_files: list[str], json_files: lis
             body=IndexPdfsReactionsBatchPostBody(
                 # Our list of ReactionMiner PDF inputs
                 pdf_files=[File(
-                    file_name=file.split('/')[-1],
-                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, file)),
+                    file_name=filename,
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, filename)),
                     mime_type='application/pdf'
-                ) for file in pdf_files],
+                ) for filename in pdf_files],
 
                 # Our list of ReactionMiner JSON outputs
                 json_reaction_files=[File(
-                    file_name=file.split('/')[-1],
-                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, file)),
+                    file_name=filename,
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, filename)),
                     mime_type='application/json'
-                ) for file in json_files],
+                ) for filename in json_files],
 
                 # The CSV created earlier that maps PDF file -> JSON file
                 mapping_file=File(
@@ -190,17 +191,24 @@ if __name__ == "__main__":
     logger.info(f'  Output Dir: {CHEMSCRAPER_OUTPUT_DIR}')
 
     try:
-        batches = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
-        num_batches = len(batches)
-        logger.info(f"Submitting {num_batches} batches")
-        logger.debug(str(batches))
+        pdf_files, json_files = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
+
+        batched_pdfs = split_into_batches(data=pdf_files)
+        batched_json = split_into_batches(data=json_files)
+        num_batches = len(batched_pdfs)
+
         for index in range(num_batches):
+            pdf_batch_files = batched_pdfs[index]
+            json_batch_files = batched_json[index]
+
+            logger.info(f'Submitting ChemScraper batch ({index+1}/{num_batches})')
+
             # Extract input for each batch and submit to chemscraper API
-            pdf_files, json_files, mapping = batch = batches[index]
-            num_files = len(pdf_files)
-            logger.info(f"Batch {index+1} / {num_batches}")
-            logger.debug(str(batch))
-            resp = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
+            resp = submit_to_chemscraper(
+                index_name=CHEMSCRAPER_INDEX_NAME,
+                pdf_files=pdf_batch_files,
+                json_files=json_batch_files
+            )
 
             # Raise error status if no response body
             logger.debug("Response: " + str(resp))
@@ -209,20 +217,24 @@ if __name__ == "__main__":
             if resp is not None:
                 # Convert response dictionary to JSON
                 output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output-batch-{index}.json')
-                logger.info(f'Writing ChemScraper (batch {index}/{num_batches}) output to file: {output_file_path}')
+                logger.info(f'Writing ChemScraper (batch {index+1}/{num_batches}) output to file: {output_file_path}')
                 write_json_output(output_path=output_file_path, data=resp)
             else:
                 # Handle response errors
-                raise HTTPError(code=500, msg='ERROR: Empty response encountered')
+                raise ValueError('Empty response encountered')
 
         # Zip all JSON outputs into a single JSON file for the frontend
         merged_output = {}
         for root, _, files in os.walk(CHEMSCRAPER_OUTPUT_DIR):
             for name in files:
+                if not name.startswith('chemscraper-output-batch-'):
+                    continue
+
                 batch_output_file = os.path.join(CHEMSCRAPER_OUTPUT_DIR, name)
                 try:
                     with open(batch_output_file) as f:
-                        merged_output = merged_output | json.load(fp=f)
+                        json_content = json.loads(f.read())
+                        merged_output = merged_output | json_content
                 except FileNotFoundError as ex:
                     logger.warning(f'WARNING - batch output was expected, but not found: {batch_output_file}')
                     pass
@@ -236,12 +248,12 @@ if __name__ == "__main__":
             # Write full CSV mapping to file
             logger.info(f'Writing full ChemScraper mapping CSV to file: {output_file_path}')
             csv_mapping_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'mapping.csv')
-            save_mapping_csv(file_path=csv_mapping_path, mapping=full_mapping)
+            save_mapping_file(file_path=csv_mapping_path, mapping=full_mapping)
 
             # Save mapping.json to file as well
             logger.info(f'Writing full ChemScraper mapping JSON to file: {output_file_path}')
             json_mapping_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'mapping.json')
-            save_mapping_json(file_path=json_mapping_path, mapping=full_mapping)
+            save_mapping_file(file_path=json_mapping_path, mapping=full_mapping, format='json')
         else:
             logger.error('ERROR: merged_output was empty - check that any batch produced a valid output file')
 

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -85,7 +85,7 @@ def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[st
                     logger.info(f"     Matching JSON file found: {json_file_name}")
 
                     # If this batch is too large, add it to our running list of batches
-                    if CHEMSCRAPER_BATCH_SIZE > 0 and len(pdf_files) <= CHEMSCRAPER_BATCH_SIZE:
+                    if 0 < CHEMSCRAPER_BATCH_SIZE < len(pdf_files):
                         batches.append((pdf_files[:], json_files[:], mapping.copy()))
                         pdf_files = []
                         json_files = []
@@ -170,7 +170,7 @@ def read_file_bytes(path: str) -> BinaryIO:
 
 
 # Write ChemScraper JSON response to file
-def write_json_output(output_path: str, data: object, batch_number: int = None, num_batches: int = None):
+def write_json_output(output_path: str, data: object):
     with open(output_path, "w") as f:
         json_contents = json.dumps(data, indent=4, ensure_ascii=False)
         logger.debug("Writing JSON contents: " + json_contents)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -216,9 +216,11 @@ if __name__ == "__main__":
             # Write JSON response to file
             if resp is not None:
                 # Convert response dictionary to JSON
-                output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output-batch-{index}.json')
+                output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output-batch-{index+1}.json')
                 logger.info(f'Writing ChemScraper (batch {index+1}/{num_batches}) output to file: {output_file_path}')
-                write_json_output(output_path=output_file_path, data=resp)
+                write_json_output(output_path=output_file_path, data={
+                    f'batch-{index+1}': resp
+                })
             else:
                 # TODO: Handle response errors?
                 # raise ValueError('Empty response encountered')
@@ -227,18 +229,18 @@ if __name__ == "__main__":
         # Zip all JSON outputs into a single JSON file for the frontend
         merged_output = {}
         for root, _, files in os.walk(CHEMSCRAPER_OUTPUT_DIR):
-            for name in files:
-                if not name.startswith('chemscraper-output-batch-'):
-                    continue
-
-                batch_output_file = os.path.join(CHEMSCRAPER_OUTPUT_DIR, name)
-                try:
-                    with open(batch_output_file) as f:
-                        json_content = json.loads(f.read())
-                        merged_output = merged_output | json_content
-                except FileNotFoundError as ex:
-                    logger.warning(f'WARNING - batch output was expected, but not found: {batch_output_file}')
-                    pass
+            for filename in files:
+                if filename.startswith('chemscraper-output-batch-'):
+                    batch_output_file = os.path.join(CHEMSCRAPER_OUTPUT_DIR, filename)
+                    try:
+                        with open(batch_output_file) as f:
+                            json_content = json.loads(f.read())
+                            merged_output = merged_output | json_content
+                    except FileNotFoundError as ex:
+                        logger.warning(f'WARNING - batch output was expected, but not found: {batch_output_file}')
+                        pass
+                else:
+                    logger.warning('Skipping file that is not ChemScraper output: ' + filename)
 
         # Write the merged ChemScraper JSON to output folder
         if len(merged_output) > 0:

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -163,10 +163,9 @@ def read_file_bytes(path: str) -> BinaryIO:
 
 
 # Write ChemScraper JSON response to file
-def write_json_output(output_path: str, response: HTTPValidationError):
-    logger.info(f'Writing response to file: {output_path}')
+def write_json_output(output_path: str, data: object, batch_number: int = None, num_batches: int = None):
     with open(output_path, "w") as f:
-        json_contents = json.dumps(response, indent=4, ensure_ascii=False)
+        json_contents = json.dumps(data, indent=4, ensure_ascii=False)
         logger.debug("Writing JSON contents: " + json_contents)
         f.write(json_contents)
 
@@ -183,20 +182,50 @@ if __name__ == "__main__":
     logger.info(f'  Output Dir: {CHEMSCRAPER_OUTPUT_DIR}')
 
     try:
-        pdf_files, json_files, mapping = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
-        resp = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
+        batches = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
+        num_batches = len(batches)
+        logger.info(f"Submitting {num_batches} batches")
+        logger.debug(str(batches))
+        for index in range(num_batches):
+            # Extract input for each batch and submit to chemscraper API
+            pdf_files, json_files, mapping = batch = batches[index]
+            num_files = len(pdf_files)
+            logger.info(f"Batch {index+1} / {num_batches}")
+            logger.debug(str(batch))
+            resp = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
 
-        # Raise error status if no response body
-        logger.debug("Response: " + str(resp))
+            # Raise error status if no response body
+            logger.debug("Response: " + str(resp))
 
-        # Write JSON response to file
-        if resp is not None:
-            # Convert response dictionary to JSON
-            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-            write_json_output(output_path=output_file_path, response=resp)
+            # Write JSON response to file
+            if resp is not None:
+                # Convert response dictionary to JSON
+                output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output-batch-{index}.json')
+                logger.info(f'Writing ChemScraper (batch {index}/{num_batches}) output to file: {output_file_path}')
+                write_json_output(output_path=output_file_path, data=resp)
+            else:
+                # Handle response errors
+                raise HTTPError(code=500, msg='ERROR: Empty response encountered')
+
+        # Zip all JSON outputs into a single JSON file for the frontend
+        merged_output = {}
+        for root, _, files in os.walk(CHEMSCRAPER_OUTPUT_DIR):
+            for name in files:
+                batch_output_file = os.path.join(CHEMSCRAPER_OUTPUT_DIR, name)
+                try:
+                    with open(batch_output_file) as f:
+                        merged_output = merged_output | json.load(fp=f)
+                except FileNotFoundError as ex:
+                    logger.warning(f'WARNING - batch output was expected, but not found: {batch_output_file}')
+                    pass
+
+        # Write the merged JSON to output folder
+        if len(merged_output) > 0:
+            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output.json')
+            logger.info(f'Writing full ChemScraper output to file: {output_file_path}')
+            write_json_output(output_path=output_file_path, data=merged_output)
         else:
-            # Handle response errors
-            raise HTTPError('ERROR: Empty response encountered')
+            logger.error('ERROR: merged_output was empty - check that any batch produced a valid output file')
 
     except Exception as ex:
         logger.error(f'ERROR: {ex}')

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -53,6 +53,7 @@ CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscrape
 
 full_mapping = {}
 
+
 # Read PDFs + locate matching JSONs on disk
 # Create a mapping of PDF file -> JSON file
 def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[str, str]]]:
@@ -86,10 +87,10 @@ def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[st
 
                     # If this batch is too large, add it to our running list of batches
                     if 0 < CHEMSCRAPER_BATCH_SIZE < len(pdf_files):
-                        batches.append((pdf_files[:], json_files[:], mapping.copy()))
-                        pdf_files = []
-                        json_files = []
-                        mapping = {}
+                        batches.append((pdf_files.copy(), json_files.copy(), mapping.copy()))
+                        pdf_files.clear()
+                        json_files.clear()
+                        mapping.clear()
 
                     # Maintain lists of these pairs to submit at the end
                     full_mapping[pdf_file_name] = mapping[pdf_file_name] = json_file_name

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -220,8 +220,9 @@ if __name__ == "__main__":
                 logger.info(f'Writing ChemScraper (batch {index+1}/{num_batches}) output to file: {output_file_path}')
                 write_json_output(output_path=output_file_path, data=resp)
             else:
-                # Handle response errors
-                raise ValueError('Empty response encountered')
+                # TODO: Handle response errors?
+                # raise ValueError('Empty response encountered')
+                logger.warning(f'Empty response encountered from ChemScraper API: {resp} - skipped writing output JSON')
 
         # Zip all JSON outputs into a single JSON file for the frontend
         merged_output = {}

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -51,6 +51,7 @@ CHEMSCRAPER_BATCH_SIZE = int(os.environ.get('CHEMSCRAPER_BATCH_SIZE', '10'))
 # We will override this default in production
 CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-services-staging.staging.svc.cluster.local:8000')
 
+full_mapping = {}
 
 # Read PDFs + locate matching JSONs on disk
 # Create a mapping of PDF file -> JSON file
@@ -91,7 +92,7 @@ def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[st
                         mapping = {}
 
                     # Maintain lists of these pairs to submit at the end
-                    mapping[pdf_file_name] = json_file_name
+                    full_mapping[pdf_file_name] = mapping[pdf_file_name] = json_file_name
                     pdf_files.append(pdf_file_path)
                     json_files.append(json_file_path)
 
@@ -117,6 +118,12 @@ def save_mapping_csv(file_path: str, mapping: dict[str, str]):
             json_file = mapping[pdf_file]
             f.write(f'{index},{pdf_file},{json_file}\n')
             index += 1
+
+
+# Write mapping.json to file, and save this file to disk
+def save_mapping_json(file_path, mapping):
+    with open(file_path, 'w') as f:
+        json.dump(mapping, f, indent=4)
 
 
 # Submit mapping + related files to Chemscraper API
@@ -219,11 +226,21 @@ if __name__ == "__main__":
                     logger.warning(f'WARNING - batch output was expected, but not found: {batch_output_file}')
                     pass
 
-        # Write the merged JSON to output folder
+        # Write the merged ChemScraper JSON to output folder
         if len(merged_output) > 0:
-            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, f'chemscraper-output.json')
+            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
             logger.info(f'Writing full ChemScraper output to file: {output_file_path}')
             write_json_output(output_path=output_file_path, data=merged_output)
+
+            # Write full CSV mapping to file
+            logger.info(f'Writing full ChemScraper mapping CSV to file: {output_file_path}')
+            csv_mapping_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'mapping.csv')
+            save_mapping_csv(file_path=csv_mapping_path, mapping=full_mapping)
+
+            # Save mapping.json to file as well
+            logger.info(f'Writing full ChemScraper mapping JSON to file: {output_file_path}')
+            json_mapping_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'mapping.json')
+            save_mapping_json(file_path=json_mapping_path, mapping=full_mapping)
         else:
             logger.error('ERROR: merged_output was empty - check that any batch produced a valid output file')
 

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -7,7 +7,7 @@ from urllib.error import HTTPError
 import requests
 import sys
 import traceback
-from typing import BinaryIO
+from typing import BinaryIO, Tuple
 from io import BytesIO
 
 import torch
@@ -43,6 +43,10 @@ CHEMSCRAPER_OUTPUT_DIR = os.environ.get('CHEMSCRAPER_OUTPUT_DIR', CHEMSCRAPER_RE
 # Used when submitting to the /search endpoint
 CHEMSCRAPER_INDEX_NAME = os.environ.get('CHEMSCRAPER_INDEX_NAME', os.environ.get('JOB_ID', 'test'))
 
+# Maximum number of PDFs to send for each batch of ChemScraper requests
+# Setting this to 0 or a negative number will run all PDFs in a single batch
+CHEMSCRAPER_BATCH_SIZE = int(os.environ.get('CHEMSCRAPER_BATCH_SIZE', '10'))
+
 # Base URL to ChemScraper API
 # We will override this default in production
 CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-services-staging.staging.svc.cluster.local:8000')
@@ -50,11 +54,12 @@ CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscrape
 
 # Read PDFs + locate matching JSONs on disk
 # Create a mapping of PDF file -> JSON file
-def parse_input_files(pdf_input_dir):
+def parse_input_files(pdf_input_dir) -> list[Tuple[list[str], list[str], dict[str, str]]]:
     # Loop to build up CSV mapping and file lists
     mapping = {}
     pdf_files = []
     json_files = []
+    batches = []
 
     # Walk input PDF directory looking for PDF files
     for root, _, files in os.walk(pdf_input_dir):
@@ -78,21 +83,31 @@ def parse_input_files(pdf_input_dir):
                     # For each matching PDF-JSON pair, add to CSV mapping
                     logger.info(f"     Matching JSON file found: {json_file_name}")
 
+                    # If this batch is too large, add it to our running list of batches
+                    if CHEMSCRAPER_BATCH_SIZE > 0 and len(pdf_files) <= CHEMSCRAPER_BATCH_SIZE:
+                        batches.append((pdf_files[:], json_files[:], mapping.copy()))
+                        pdf_files = []
+                        json_files = []
+                        mapping = {}
+
                     # Maintain lists of these pairs to submit at the end
                     mapping[pdf_file_name] = json_file_name
                     pdf_files.append(pdf_file_path)
                     json_files.append(json_file_path)
+
+                    # Make sure to add in the last batch every time
+                    batches.append((pdf_files, json_files, mapping))
 
         logger.debug('PDF Files: ' + str(pdf_files))
         logger.debug('JSON Files: ' + str(json_files))
         logger.debug('Mapping: ' + str(mapping))
 
         # Return lists of files and CSV mapping
-        return pdf_files, json_files, mapping
+        return batches
 
 
 # Write mapping.csv to file, and submit this file with our request
-def save_mapping_csv(file_path, mapping):
+def save_mapping_csv(file_path: str, mapping: dict[str, str]):
     index = 0
     with open(file_path, 'w') as f:
         # Write CSV headers - this is important
@@ -105,7 +120,7 @@ def save_mapping_csv(file_path, mapping):
 
 
 # Submit mapping + related files to Chemscraper API
-def submit_to_chemscraper(index_name: str, pdf_files, json_files, mapping):
+def submit_to_chemscraper(index_name: str, pdf_files: list[str], json_files: list[str], mapping: dict[str, str]):
     # Save mapping.csv to disk, upload to MinIO later
     mapping_csv_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')
     save_mapping_csv(file_path=mapping_csv_file_path, mapping=mapping)
@@ -162,6 +177,7 @@ def write_json_output(output_path: str, response: HTTPValidationError):
 if __name__ == "__main__":
     logger.info(f'Submitting these files to ChemScraper')
     logger.info(f'  Index Name: {CHEMSCRAPER_INDEX_NAME}')
+    logger.info(f'  Batch Size: {CHEMSCRAPER_BATCH_SIZE}')
     logger.info(f'  PDF  Input Dir: {CHEMSCRAPER_PDF_INPUT_DIR}')
     logger.info(f'  JSON Input Dir: {CHEMSCRAPER_REACTIONMINER_JSON_DIR}')
     logger.info(f'  Output Dir: {CHEMSCRAPER_OUTPUT_DIR}')


### PR DESCRIPTION
## Problem
ChemScraper runs out of resources when trying to run too many PDFs in a single request

## Approach
* feat: added `CHEMSCRAPER_BATCH_SIZE` that allows you to control the maximum number of PDFs that can be sent in a single bulk request to the ChemScraper API

## How to Test
1. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Files/upload_file__bucket_name__upload_post
2. Upload our 19 example PDF papers to the `reactionminer` using a new `job_id` (or skip this step and use existing `job_id=19papers` where these have already been uploaded)
3. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Jobs/create_job__job_type__jobs_post
4. Submit this job for execution to Kubernetes:
    * Bucket Name: `reactionminer`
    * Request Body, use your own `job_id` or use `19papers` for the full example:
```json
{
  "job_id": "19 papers"
}
```
5. Wait for the job to finish executing, then check the logs
    * You should see that ChemScraper requests are submitted in batches
    * You should see that at most, each batch contains a number of PDFs specified by `CHEMSCRAPER_BATCH_SIZE`